### PR TITLE
BUG: Fix the chat input box failing to auto-shrink after sending a message

### DIFF
--- a/src/functions/chatAugments.js
+++ b/src/functions/chatAugments.js
@@ -300,6 +300,8 @@ export default function chatAugments() {
               }
               inputChat.value = `${prefix}(${text.replace(/\)/g, CLOSINGBRACKETINDICATOR)}`;
             }
+            inputChat.style.height = "100%";
+            inputChat.style.height = `${inputChat.scrollHeight}px`;
             ChatRoomSendChat();
             return true;
           }


### PR DESCRIPTION
Incorporates the [BondageProjects/Bondage-College#5083](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5083) hotfix changes into WCE's `ChatRoomKeyDown()` hook.