### PR TITLE
MAINT: Adapt to R107 CSS button color changes

### DIFF
--- a/src/functions/wceStyles.ts
+++ b/src/functions/wceStyles.ts
@@ -367,11 +367,11 @@ export default function wceStyles(): void {
   }
   #wce-chat-baby-talk[data-state="ignore"]::before,
   #wce-chat-stutters[data-state="ignore"]::before {
-    background-color: #bbb;
+    --button-color: #bbb;
   }
   #wce-chat-baby-talk[data-state="preserve"]::before,
   #wce-chat-stutters[data-state="preserve"]::before {
-    background-color: #666;
+    --button-color: #666;
   }
   `;
   const head = document.head || document.getElementsByTagName("head")[0];

--- a/src/functions/wceStyles.ts
+++ b/src/functions/wceStyles.ts
@@ -367,11 +367,11 @@ export default function wceStyles(): void {
   }
   #wce-chat-baby-talk[data-state="ignore"]::before,
   #wce-chat-stutters[data-state="ignore"]::before {
-    --button-color: #bbb;
+    ${GameVersion === "R106" ? "background-color" : "--button-color"}: #bbb;
   }
   #wce-chat-baby-talk[data-state="preserve"]::before,
   #wce-chat-stutters[data-state="preserve"]::before {
-    --button-color: #666;
+    ${GameVersion === "R106" ? "background-color" : "--button-color"}: #666;
   }
   `;
   const head = document.head || document.getElementsByTagName("head")[0];


### PR DESCRIPTION
Note: this PR should not be merged until R107 is live and R106 support is ready to be dropped.

This PR adapts to the CSS button changes introduced in [BondageProjects/Bondage-College#5127](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5127?commit_id=d265b63cea043309cc7cd14cd1ccb2eab665feaa), which among others splits the managing of button background colors into three distinct variables: `--button-color`, `--disabled-color` and `--hover-color`; variables that, in most cases, should modified instead of directly setting `background-color` itself. 

The goal of these changes was to make it easier to only override the "default" background color while leaving the styling of disabled and hover colors alone. As such, the WCE buttons should now display the expected hovering color (cyan) again upon, well..., hovering over them, as the hovering color was previously overriding by the id-level `background-color` declaration of the `ignore` and `preserve` states.