### PR TITLE
MAINT: Adapt to the R109 crafted item description changes

### DIFF
--- a/src/functions/crafting.ts
+++ b/src/functions/crafting.ts
@@ -3,6 +3,9 @@ import { waitFor, isNonNullObject, parseJSON, objEntries, isString, drawTooltip 
 import { displayText } from "../util/localization";
 import { debug, logWarn, logError } from "../util/logger";
 
+// >= R109
+declare const CraftingDescription: undefined | { Decode: (description: string) => string };
+
 export default async function crafting(): Promise<void> {
   await waitFor(() => Array.isArray(Commands) && Commands.length > 0);
 
@@ -91,7 +94,9 @@ export default async function crafting(): Promise<void> {
         const { Craft } = item;
         if (MouseIn(x, y, DialogInventoryGrid.itemWidth, DialogInventoryGrid.itemHeight) && Craft) {
           drawTooltip(x, y, DialogInventoryGrid.itemWidth, displayText(Craft.Property), "center");
-          drawTooltip(1000, y - 70, 975, `${displayText("Description:")} ${Craft.Description || "<no description>"}`, "left");
+
+          const craftDescription = typeof CraftingDescription === "undefined" ? Craft.Description : CraftingDescription.Decode(Craft.Description); // R109
+          drawTooltip(1000, y - 70, 975, `${displayText("Description:")} ${craftDescription || "<no description>"}`, "left");
         }
       }
       return ret;


### PR DESCRIPTION
Xref [BondageProjects/Bondage-College#5210](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5210)

Previously available in MBS, R109 adds the (optional) ability to use longer crafted item descriptions at the cost of limiting the available character set to extended ASCII. As a consequence, the affected descriptions now have to be decoded in order to retrieve the actual legible item description that can be used by WCE's crafting tooltip.