### PR TITLE
FIX: Remove scroll with meta-up/down

### DIFF
--- a/src/functions/chatAugments.js
+++ b/src/functions/chatAugments.js
@@ -265,10 +265,6 @@ export default function chatAugments() {
           ChatRoomSendChat();
           return true;
         }
-        if (event.metaKey && (event.key === "ArrowUp" || event.key === "ArrowDown")) {
-          ChatRoomScrollHistory(event.key === "ArrowUp");
-          return true;
-        }
       }
       return next([event]);
     }


### PR DESCRIPTION
This conflicts with macOS's caret movement, which makes "move to start/end" (what ⌘↑/↓ does) turn into what Fn↑/↓ does already, and makes it very easy to lose what you're currently typing into chat, as the history scroll doesn't preserve that.

That was *added* in 2076f35 (emphasis because I'm sure FBC didn't do that initially, and that change adds this), which is a while back, but I either not play BC enough or spend too much time in dev, where I disable everything, so I never noticed it.

Possibly could be made into a setting, if keeping that would be preferable, because it's really bothering me and my macOS keyboard-fu.