### PR TITLE
BUG: Fix collapse of the layer-specific layering DIV

### DIFF
--- a/src/functions/layeringMenu.ts
+++ b/src/functions/layeringMenu.ts
@@ -40,17 +40,27 @@ export default async function layeringMenu(): Promise<void> {
       const defaultItemHide = Layering.Asset.Hide || [];
       if (defaultItemHide.length === 0) return ret;
       const overrideItemHide = Layering.Item.Property.wceOverrideHide || defaultItemHide;
+
+      // Move the scrollbar-related CSS settings from the layer-specific priority config to the root
+      const root = document.getElementById("layering");
+      if (!root) {
+        return ret;
+      } else {
+        root.classList.add("scroll-box");
+        root.querySelector("#layering-layer-div")?.classList.remove("scroll-box");
+      }
+
       ElementCreate({
         tag: "h1",
         attributes: { id: "layering-hide-header" },
-        parent: document.getElementById("layering"),
+        parent: root,
         children: [displayText("[WCE] Configure layer hiding")],
       });
       ElementCreate({
         tag: "form",
         attributes: { id: "layering-hide-div" },
         classList: ["layering-layer-inner-grid"],
-        parent: document.getElementById("layering"),
+        parent: root,
         children: defaultItemHide.map(h => ({
           tag: "div",
           classList: ["layering-pair"],


### PR DESCRIPTION
Fixes the issue below (the fully collapsed "configure layer specific priority" section) by moving the in [BondageProjects/Bondage-College#5343](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5343) introduced CSS class for Y-scrollable elements to the, now-scrollable, root element.
As far as I can tell the issue is to be related to the previous `overflow` value, but this does admittedly seem to be a bit of a case of "CSS working in mysterious ways"...

![image](https://github.com/user-attachments/assets/6eaac702-d78b-4829-9072-db58385255ff)
