### PR TITLE
MAINT: Adapt to R113 `CharacterBuildDialog()` changes

### DIFF
--- a/src/functions/forcedClubSlave.ts
+++ b/src/functions/forcedClubSlave.ts
@@ -127,6 +127,28 @@ export default async function forcedClubSlave(): Promise<void> {
         return ret;
       }
     );
+
+    if (GameVersion !== "R112") {
+      // Delay any reloads until all other hooks have finished running
+      SDK.hookFunction(
+        "CharacterBuildDialog",
+        HOOK_PRIORITIES.OverrideBehaviour,
+        (args, next) => {
+          // @ts-expect-error: New R113 parameter
+          // eslint-disable-next-line prefer-destructuring
+          const reload: boolean = args[3];
+          // @ts-expect-error: New R113 parameter
+          args[3] = false;
+          const ret = next(args);
+          if (reload && DialogMenuMode === "dialog") {
+            // @ts-expect-error: New R113 object
+            const dialogMenu = DialogMenuMapping.dialog as DialogMenu;
+            dialogMenu.Reload(null, null, { reset: true });
+          }
+          return ret;
+        }
+      );
+    }
   }
 
   const patch = patchDialog();


### PR DESCRIPTION
Xref [BondageProjects/Bondage-College#5358](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5358) and its [BondageProjects/Bondage-College#5397](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5397) follow up.

Aforementioned PR(s) have converted the `dialog` dialog menu mode from canvas to DOM, with one of the changes now causing `CharacterBuildDialog()` calls to initialize a reload of the sub screen in order to keep it and the relevant `Character.Dialog` in sync.

This does however require a minor change to how WCE handles its `CharacterBuildDialog()` hooking, as prior to this PR the additional dialog entries would only be added _after_ a (potential) refresh of the screen had already been wrapped up (the actual UI thus failing to properly incorporate them). As a fix, the reloading has now simply been delayed via a new high-priority hook.