### PR TITLE
MAINT: Adapt the `CharacterBuildDialog` hook to R115 `DialogMenu.Reload()` changes

### DIFF
--- a/src/functions/forcedClubSlave.ts
+++ b/src/functions/forcedClubSlave.ts
@@ -122,7 +122,14 @@ export default async function forcedClubSlave(): Promise<void> {
       ([C, CSV, functionPrefix, reload], next) => {
         const ret = next([C, CSV, functionPrefix, false]);
         if (isCharacter(C) && C.IsOnline()) appendDialog(C);
-        if (reload && DialogMenuMode === "dialog") DialogMenuMapping.dialog.Reload(null, null, { reset: true });
+        if (reload && DialogMenuMode === "dialog") {
+          if (GameVersion === "R114") {
+            DialogMenuMapping.dialog.Reload(null, null, { reset: true });
+          } else {
+            // @ts-expect-error: Requires R115
+            DialogMenuMapping.dialog.Reload(null, { reset: true });
+          }
+        }
         return ret;
       }
     );


### PR DESCRIPTION
Xref [BondageProjects/Bondage-College#5474](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5474)

As of R115 `DialogMenu.Reload()`'s signature will switch from:
`(...args: any[], options?: Record<string, any>) => any` 
to something along the lines of
`(args: Record<string, any>, options?: Record<string, any>) => any`

Nothing too big, but it is a change relevant for one of WCE's hooks, the latter of which has now been updated.