### PR TITLE
MAINT: Adapt to the R115 checkbox styling changes

### DIFF
--- a/src/functions/layeringMenu.ts
+++ b/src/functions/layeringMenu.ts
@@ -58,7 +58,7 @@ export default async function layeringMenu(): Promise<void> {
           tag: "div",
           classList: ["layering-pair"],
           children: [
-            // NOTE: Consider using `ElementCheckbox.Create()` for checkbox construction once R115 is live
+            // ToDo: Consider using `ElementCheckbox.Create()` for checkbox construction once R115 is live
             {
               tag: "input",
               attributes: { type: "checkbox", name: "checkbox-hide", value: h, disabled: Layering.Readonly, checked: overrideItemHide.includes(h) },

--- a/src/functions/layeringMenu.ts
+++ b/src/functions/layeringMenu.ts
@@ -58,10 +58,11 @@ export default async function layeringMenu(): Promise<void> {
           tag: "div",
           classList: ["layering-pair"],
           children: [
+            // NOTE: Consider using `ElementCheckbox.Create()` for checkbox construction once R115 is live
             {
               tag: "input",
               attributes: { type: "checkbox", name: "checkbox-hide", value: h, disabled: Layering.Readonly, checked: overrideItemHide.includes(h) },
-              classList: [],
+              classList: ["checkbox"],
               eventListeners: {
                 click: () => {
                   const hideForm: HTMLFormElement = document.getElementById("layering-wce-hide-div") as HTMLFormElement;


### PR DESCRIPTION
Xref [BondageProjects/Bondage-College#5464](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5464)

Minor follow up on https://github.com/KittenApps/WCE/pull/81 concerning a R115 change that I forgot to include:

Aforementioned upstream PR has added a new namespace specifically for the construction of DOM checkboxes, and, more importantly for WCE here, has moved the previously unconditional `<input type="checkbox">` styling to a dedicated `.checkbox` CSS class. This PR simply ensures that the WCE checkboxes in its layering menu extension retain their previous styling.