### PR TITLE
MAINT: Adapt the WCE animation engine to the R115 `Character.ActiveExpression` introduction

### DIFF
--- a/src/functions/automaticExpressions.js
+++ b/src/functions/automaticExpressions.js
@@ -849,6 +849,7 @@ export default async function automaticExpressions() {
     }
 
     if (Object.keys(desiredExpression).length > 0) {
+      let refreshExpressionScreen = false;
       for (const t of Object.keys(desiredExpression)) {
         if (BCX?.getRuleState("block_changing_emoticon")?.isEnforced && t === "Emoticon") {
           continue;
@@ -860,8 +861,21 @@ export default async function automaticExpressions() {
           Group: t,
           Appearance: ServerAppearanceBundle(Player.Appearance),
         });
+
+        if (GameVersion !== "R114" && desiredExpression[t].Duration < 0) {
+          refreshExpressionScreen = true;
+          Player.ActiveExpression.setWithoutReload(/** @type {ExpressionGroupName} */(t), desiredExpression[t].Expression);
+        }
       }
 
+      if (
+        GameVersion !== "R114" &&
+        refreshExpressionScreen &&
+        /** @type {unknown} */(DialogSelfMenuSelected) === "Expression" &&
+        DialogSelfMenuMapping.Expression.C.IsPlayer()
+      ) {
+        DialogSelfMenuMapping.Expression.Reload();
+      }
       needsRefresh = true;
     }
 
@@ -926,6 +940,14 @@ export default async function automaticExpressions() {
     if (poseUpdate) {
       Player.ActivePose = poseUpdate;
       ServerSend("ChatRoomCharacterPoseUpdate", { Pose: poseUpdate });
+
+      if (
+        GameVersion !== "R114" &&
+        /** @type {unknown} */(DialogSelfMenuSelected) === "Pose" &&
+        DialogSelfMenuMapping.Pose.C.IsPlayer()
+      ) {
+        DialogSelfMenuMapping.Pose.Reload();
+      }
     }
 
     if (needsRefresh) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
 		"node_modules/@total-typescript/ts-reset/dist/recommended.d.ts",
 		"node_modules/bc-stubs/bc/**/*.d.ts",
 		"types/wce.d.ts",
+		"types/automaticExpressions.d.ts",
 		"src/**/*.js",
 		"src/**/*.ts"
 	],

--- a/types/automaticExpressions.d.ts
+++ b/types/automaticExpressions.d.ts
@@ -1,0 +1,13 @@
+// >= R115
+
+interface PlayerCharacter {
+  readonly ActiveExpression: (
+    Partial<Record<ExpressionGroupName, ExpressionName>>
+    & {
+      setWithoutReload(key: ExpressionGroupName, value: ExpressionName): void;
+      deleteWithoutReload(key: ExpressionGroupName): void;
+    }
+  );
+}
+
+declare const DialogSelfMenuMapping: { Expression: DialogMenu; Pose: DialogMenu };


### PR DESCRIPTION
Xref [BondageProjects/Bondage-College#5516](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5516)

The R115 PR mentioned above converts the dialog self menu (those leftern panels containing things like the expression menu) from canvas to DOM, requiring some minor additional book keeping changes in WCE's animation engine. 

These changes fall into one of two categories: requesting a soft reload of the relevant screen when appropriate, and, in the case of expressions, updating the user selected expression in the screen's UI via a new `PlayerCharacter.ActiveExpression` property. In the latter case distinction is made between permanent expressions (well... those with an indeterminate duration that is) and temporary ones that are part of some sort of animation sequence, with only the former being considered "active expressions".