### PR TITLE
MAINT: Adapt the WCE `ChatRoomGenerateChatRoomChatMessage()` hook to the new R115 reply system

### DIFF
--- a/src/functions/antiGarbling.ts
+++ b/src/functions/antiGarbling.ts
@@ -8,12 +8,9 @@ export default function antiGarbling(): void {
   SDK.hookFunction(
     "ChatRoomGenerateChatRoomChatMessage",
     HOOK_PRIORITIES.Top,
-    ([type, msg, ...args], next) => {
-      const typeR115 = type as "Chat" | "Whisper" | "Emote";
-      if (!fbcSettings.antiGarble || typeR115 === "Emote") return next([type, msg, ...args]);
+    ([type, msg, replyId, ...args], next) => {
+      if (!fbcSettings.antiGarble || type === "Emote") return next([type, msg, ...args]);
 
-      // @ts-expect-error: >= R115
-      const [replyId]: undefined | string = args;
       const lastRange = SpeechGetOOCRanges(msg).pop();
       if (Player.ChatSettings.OOCAutoClose && typeof lastRange === "object" && msg.charAt(lastRange.start + lastRange.length - 1) !== ")" &&
         lastRange.start + lastRange.length === msg.length && lastRange.length !== 1) {
@@ -53,11 +50,9 @@ export default function antiGarbling(): void {
       }
 
       const Dictionary: ChatMessageDictionary = [{ Effects: process.effects, Original: originalMsg }];
+      // ToDo: remove GameVersion !== "R114" check once R115 is released
       if (GameVersion !== "R114" && replyId) {
-        // @ts-expect-error: >= R115
         Dictionary.push({ ReplyId: replyId, Tag: "ReplyId" });
-        // @ts-expect-error: >= R115
-        // eslint-disable-next-line
         ChatRoomMessageReplyStop();
       }
       return { Content: process.text, Type: type, Dictionary };


### PR DESCRIPTION
Xref [BondageProjects/Bondage-College#5486](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5486)

A new Discord-esque reply system got added in R115 for chat messages and whispers, but this change involved a set of `ChatRoomGenerateChatRoomChatMessage()` changes that, prior to this PR, had yet to be propagated to WCE's hook of aforementioned function, both breaking the reply system and causing `Emote`-type messages to be (potentially) garbled.