### PR TITLE
Fix wardrobe length after loading local wardrobe

### DIFF
--- a/src/util/settings.ts
+++ b/src/util/settings.ts
@@ -218,6 +218,7 @@ export const defaultSettings = {
         if (Player.Wardrobe) {
           WardrobeSize = LOCAL_WARDROBE_SIZE;
           loadLocalWardrobe(Player.Wardrobe);
+          WardrobeFixLength();
           // Call compress wardrobe to save existing outfits, if another addon has extended the wardrobe
           CharacterCompressWardrobe(Player.Wardrobe);
         } else {


### PR DESCRIPTION
Additional slots were not getting added when the local wardrobe was enabled, so player that didn't already have local wardrobe data saved wouldn't get any extra wardrobe slots. `loadExtendedWardrobe` calls `WardrobeFixLength()` to add the new slots but `loadLocalWardrobe` doesn't. I've added it to settings in the same place that the wardrobe size is adjusted for the local wardrobe, although for extended wardrobes this is all done in `loadExtendedWardrobe`.