### PR TITLE
MAINT: Use the more standard `ChatRoomAppendChat()` function for appending messages to the chat log

### DIFF
--- a/src/functions/pendingMessages.js
+++ b/src/functions/pendingMessages.js
@@ -95,14 +95,7 @@ export default function pendingMessages() {
           loader.appendChild(dot);
         }
         div.appendChild(loader);
-        const scroll = ElementIsScrolledToEnd("TextAreaChatLog");
-        const textarea = document.getElementById("TextAreaChatLog");
-        if (textarea) {
-          textarea.appendChild(div);
-          if (scroll) {
-            ElementScrollToEnd("TextAreaChatLog");
-          }
-        }
+        ChatRoomAppendChat(div);
       }
       return next(args);
     }


### PR DESCRIPTION
Use the more standard `ChatRoomAppendChat()` function for appending messages to the chat log.

This is particularly important in light of [BondageProjects/Bondage-College#5559](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5559) in R116, as aforementioned function will now used for setting the message's metadata-esque element with the time and sender number (previously a pseudo element; now a proper element).