### PR TITLE
Make the friend online/offline notifications silent again

### DIFF
--- a/src/functions/friendPresenceNotifications.js
+++ b/src/functions/friendPresenceNotifications.js
@@ -46,7 +46,7 @@ export default async function friendPresenceNotifications() {
       if (fbcSettings.friendNotificationsInChat && CurrentScreen === "ChatRoom") {
         fbcChatNotify(displayText("Now online: $list", { $list: list }));
       } else {
-        fbcNotify(displayText("Now online: $list", { $list: list }), 5000, true);
+        fbcNotify(displayText("Now online: $list", { $list: list }), 5000, true, true);
       }
     }
     if (fbcSettings.friendOfflineNotifications && offlineFriends.length) {
@@ -62,7 +62,7 @@ export default async function friendPresenceNotifications() {
       if (fbcSettings.friendNotificationsInChat && CurrentScreen === "ChatRoom") {
         fbcChatNotify(displayText("Now offline: $list", { $list: list }));
       } else {
-        fbcNotify(displayText("Now offline: $list", { $list: list }), 5000, true);
+        fbcNotify(displayText("Now offline: $list", { $list: list }), 5000, true, true);
       }
     }
     lastFriends = data.Result;


### PR DESCRIPTION
This passes a silent: true flag to the friendlist notification, since people have been complaining about those. 