### PR TITLE
Fix inability to stand up

### DIFF
--- a/src/functions/automaticExpressions.js
+++ b/src/functions/automaticExpressions.js
@@ -938,10 +938,8 @@ export default async function automaticExpressions() {
         },
       };
     }
-    const basePoseMatcher = /^Base(Lower|Upper)$/u;
     const newPose = Object.values(desiredPose)
-      .map(p => p.Pose)
-      .filter(p => !basePoseMatcher.test(p));
+      .map(p => p.Pose);
     if (JSON.stringify(Player.ActivePose) !== JSON.stringify(newPose)) {
       poseUpdate = newPose;
       needsRefresh = true;


### PR DESCRIPTION
This is an attempt to fix #133. Apparently the new BC version does not accept an empty ActivePose array anymore and requires it to has at least ` ['BaseUpper', 'BaseLower']`. This PR makes it so WCE does not filter out `Base(Upper|Lower)` poses when updating the ActivePose array.

I've tested it locally and it seems to work, but due to the complexity of the Animation Engine code - as well as the BC's poses code in general - I can't be sure it works correctly in all obscure cases, so I'd appreciate a review from more experienced people.