### PR TITLE
BUG: Fix missing CSS variables for the chatroom garble level `<select>` tooltip

### DIFF
--- a/src/functions/antiGarbling.ts
+++ b/src/functions/antiGarbling.ts
@@ -143,6 +143,7 @@ export default function antiGarbling(): void {
       buttonGrid.prepend(ElementCreate({
         tag: "div",
         attributes: { hidden: true },
+        style: { "--tooltip-gap": "var(--half-gap)" },
         classList: ["wce-chat-room-select-div", "wce-chat-room-button"],
         children: [
           {


### PR DESCRIPTION
Xref [BondageProjects/Bondage-College#5928](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5928)
Fixes https://discord.com/channels/842082194209112074/968149353506160641/1441791301732405348

Fixes the tooltip overlapping the select dropdown due to a missing `--tooltip-gap` variable, as it was moved from the `.button-tooltip` class to its parent `.button` class in aforementioned PR (generally making the css a bit easier as you don't have to dig as much through child elements with the selectors).