### PR TITLE
MAINT: Adapt WCE's layering screen extension to R130

### DIFF
--- a/src/functions/layeringMenu.ts
+++ b/src/functions/layeringMenu.ts
@@ -38,6 +38,7 @@ export default async function layeringMenu(): Promise<void> {
     if (defaultItemHide.length === 0) return ret;
     const overrideItemHide = Layering.Item.Property.wceOverrideHide || defaultItemHide;
     const root = document.getElementById(Layering.ID.root);
+    // ToDo: remove once R130 is out
     if (GameVersion === "R129") {
       root.classList.add("scroll-box");
       root.querySelector("#layering-layer-div")?.classList.remove("scroll-box");
@@ -69,46 +70,44 @@ export default async function layeringMenu(): Promise<void> {
       });
     } else {
       // >= R130Beta1
-      root.querySelector(".screen-main")?.append(
-        ElementCreate({
-          tag: "fieldset",
-          attributes: { name: "wce-hide", id: "layering-wce-hide-div", "aria-labelledby": "layering-hide-header", disabled: Layering.Readonly },
-          children: [
-            { tag: "h2", attributes: { id: "layering-hide-header" }, children: [displayText("[WCE] Configure layer hiding")] },
-            {
-              tag: "fieldset",
-              classList: ["layering-layer-inner-grid"],
-              children: [
-                { tag: "legend" as const, children: ["Layers"] },
-                ...defaultItemHide.map(h => ({
-                  tag: "div" as const,
-                  classList: ["layering-pair"],
-                  children: [
-                    ElementCheckbox.Create(
-                      `layering-wce-hide-cb-${h}`,
-                      () => {
-                        const hidingInputs = Array.from(
-                          document.getElementById("layering-wce-hide-div")?.querySelectorAll<HTMLInputElement>("input[type='checkbox']") ?? []
-                        );
-                        const hiddenGroups = hidingInputs.filter(inp => inp.checked).map(inp => inp.value as AssetGroupName);
-                        Layering.Item.Property.wceOverrideHide = hiddenGroups;
-                        if (defaultItemHide.length === Layering.Item.Property.wceOverrideHide.length) delete Layering.Item.Property.wceOverrideHide;
-                        // oxlint-disable-next-line no-underscore-dangle
-                        Layering._CharacterRefresh(Layering.Character, false, false);
-                      },
-                      { value: h, checked: overrideItemHide.includes(h) },
-                      { checkbox: { attributes: { name: "checkbox-hide" } } }
-                    ),
-                    { tag: "label" as const, classList: ["layering-pair-text"], children: [h], attributes: { for: `layering-wce-hide-cb-${h}` } },
-                  ],
-                })),
-              ],
-            },
-          ],
-        })
-      );
+      console.log(root);
+      ElementCreate({
+        tag: "fieldset",
+        attributes: { name: "wce-hide", id: "layering-wce-hide-div", "aria-labelledby": "layering-hide-header", disabled: Layering.Readonly },
+        parent: root.querySelector(".screen-main"),
+        children: [
+          { tag: "h2", attributes: { id: "layering-hide-header" }, children: [displayText("[WCE] Configure layer hiding")] },
+          {
+            tag: "fieldset",
+            classList: ["layering-layer-inner-grid"],
+            children: [
+              { tag: "legend" as const, children: ["Layers"] },
+              ...defaultItemHide.map(h => ({
+                tag: "div" as const,
+                classList: ["layering-pair"],
+                children: [
+                  ElementCheckbox.Create(
+                    `layering-wce-hide-cb-${h}`,
+                    () => {
+                      const hidingInputs = document
+                        .getElementById("layering-wce-hide-div")
+                        ?.querySelectorAll<HTMLInputElement>("input[type='checkbox']:checked");
+                      Layering.Item.Property.wceOverrideHide = Array.from(hidingInputs).map(inp => inp.value as AssetGroupName);
+                      if (defaultItemHide.length === Layering.Item.Property.wceOverrideHide.length) delete Layering.Item.Property.wceOverrideHide;
+                      // oxlint-disable-next-line no-underscore-dangle
+                      Layering._CharacterRefresh(Layering.Character, false, false);
+                    },
+                    { value: h, checked: overrideItemHide.includes(h) },
+                    { checkbox: { attributes: { name: "checkbox-hide" } } }
+                  ),
+                  { tag: "label" as const, classList: ["layering-pair-text"], children: [h], attributes: { for: `layering-wce-hide-cb-${h}` } },
+                ],
+              })),
+            ],
+          },
+        ],
+      });
     }
-
     return ret;
   });
 

--- a/src/functions/layeringMenu.ts
+++ b/src/functions/layeringMenu.ts
@@ -38,34 +38,77 @@ export default async function layeringMenu(): Promise<void> {
     if (defaultItemHide.length === 0) return ret;
     const overrideItemHide = Layering.Item.Property.wceOverrideHide || defaultItemHide;
     const root = document.getElementById(Layering.ID.root);
-    root.classList.add("scroll-box");
-    root.querySelector("#layering-layer-div")?.classList.remove("scroll-box");
-    ElementCreate({ tag: "h1", attributes: { id: "layering-hide-header" }, parent: root, children: [displayText("[WCE] Configure layer hiding")] });
-    ElementCreate({
-      tag: "form",
-      attributes: { id: "layering-wce-hide-div" },
-      classList: ["layering-layer-inner-grid"],
-      parent: root,
-      children: defaultItemHide.map(h => ({
-        tag: "div",
-        classList: ["layering-pair"],
-        children: [
-          ElementCheckbox.Create(
-            `layering-wce-hide-cb-${h}`,
-            () => {
-              const hideForm: HTMLFormElement = document.getElementById("layering-wce-hide-div") as HTMLFormElement;
-              Layering.Item.Property.wceOverrideHide = new FormData(hideForm).getAll("checkbox-hide") as AssetGroupName[];
-              if (defaultItemHide.length === Layering.Item.Property.wceOverrideHide.length) delete Layering.Item.Property.wceOverrideHide;
-              // oxlint-disable-next-line no-underscore-dangle
-              Layering._CharacterRefresh(Layering.Character, false, false);
+    if (GameVersion === "R129") {
+      root.classList.add("scroll-box");
+      root.querySelector("#layering-layer-div")?.classList.remove("scroll-box");
+      ElementCreate({ tag: "h1", attributes: { id: "layering-hide-header" }, parent: root, children: [displayText("[WCE] Configure layer hiding")] });
+      ElementCreate({
+        tag: "form",
+        attributes: { id: "layering-wce-hide-div" },
+        classList: ["layering-layer-inner-grid"],
+        parent: root,
+        children: defaultItemHide.map(h => ({
+          tag: "div",
+          classList: ["layering-pair"],
+          children: [
+            ElementCheckbox.Create(
+              `layering-wce-hide-cb-${h}`,
+              () => {
+                const hideForm: HTMLFormElement = document.getElementById("layering-wce-hide-div") as HTMLFormElement;
+                Layering.Item.Property.wceOverrideHide = new FormData(hideForm).getAll("checkbox-hide") as AssetGroupName[];
+                if (defaultItemHide.length === Layering.Item.Property.wceOverrideHide.length) delete Layering.Item.Property.wceOverrideHide;
+                // oxlint-disable-next-line no-underscore-dangle
+                Layering._CharacterRefresh(Layering.Character, false, false);
+              },
+              { value: h, disabled: Layering.Readonly, checked: overrideItemHide.includes(h) },
+              { checkbox: { attributes: { name: "checkbox-hide" } } }
+            ),
+            { tag: "span", classList: ["layering-pair-text"], children: [h] },
+          ],
+        })),
+      });
+    } else {
+      // >= R130Beta1
+      root.querySelector(".screen-main")?.append(
+        ElementCreate({
+          tag: "fieldset",
+          attributes: { name: "wce-hide", id: "layering-wce-hide-div", "aria-labelledby": "layering-hide-header", disabled: Layering.Readonly },
+          children: [
+            { tag: "h2", attributes: { id: "layering-hide-header" }, children: [displayText("[WCE] Configure layer hiding")] },
+            {
+              tag: "fieldset",
+              classList: ["layering-layer-inner-grid"],
+              children: [
+                { tag: "legend" as const, children: ["Layers"] },
+                ...defaultItemHide.map(h => ({
+                  tag: "div" as const,
+                  classList: ["layering-pair"],
+                  children: [
+                    ElementCheckbox.Create(
+                      `layering-wce-hide-cb-${h}`,
+                      () => {
+                        const hidingInputs = Array.from(
+                          document.getElementById("layering-wce-hide-div")?.querySelectorAll<HTMLInputElement>("input[type='checkbox']") ?? []
+                        );
+                        const hiddenGroups = hidingInputs.filter(inp => inp.checked).map(inp => inp.value as AssetGroupName);
+                        Layering.Item.Property.wceOverrideHide = hiddenGroups;
+                        if (defaultItemHide.length === Layering.Item.Property.wceOverrideHide.length) delete Layering.Item.Property.wceOverrideHide;
+                        // oxlint-disable-next-line no-underscore-dangle
+                        Layering._CharacterRefresh(Layering.Character, false, false);
+                      },
+                      { value: h, checked: overrideItemHide.includes(h) },
+                      { checkbox: { attributes: { name: "checkbox-hide" } } }
+                    ),
+                    { tag: "label" as const, classList: ["layering-pair-text"], children: [h], attributes: { for: `layering-wce-hide-cb-${h}` } },
+                  ],
+                })),
+              ],
             },
-            { value: h, disabled: Layering.Readonly, checked: overrideItemHide.includes(h) },
-            { checkbox: { attributes: { name: "checkbox-hide" } } }
-          ),
-          { tag: "span", classList: ["layering-pair-text"], children: [h] },
-        ],
-      })),
-    });
+          ],
+        })
+      );
+    }
+
     return ret;
   });
 

--- a/src/functions/wceStyles.ts
+++ b/src/functions/wceStyles.ts
@@ -346,6 +346,7 @@ export default function wceStyles(): void {
     --button-color: #666;
   }
   `;
+  // ToDo: remove once R130 is out
   if (GameVersion === "R129") {
     css += `
     #layering {

--- a/src/functions/wceStyles.ts
+++ b/src/functions/wceStyles.ts
@@ -3,7 +3,7 @@ import { BCE_COLOR_ADJUSTMENTS_CLASS_NAME, DARK_INPUT_CLASS, WHISPER_CLASS } fro
 const INPUT_WARN_CLASS = "bce-input-warn";
 
 export default function wceStyles(): void {
-  const css = /* CSS */ `
+  let css = /* CSS */ `
   .bce-beep-link {
     text-decoration: none;
   }
@@ -293,34 +293,6 @@ export default function wceStyles(): void {
     z-index: 100 !important;
   }
 
-  #layering {
-    grid-template:
-      "asset-header button-grid" min-content
-      "asset-grid asset-grid" min-content
-      "layer-header layer-header" min-content
-      "layer-grid layer-grid" auto
-      "layer-hide-header layer-hide-header" min-content
-      "layer-hide-grid layer-hide-grid" auto
-      / auto min-content
-    ;
-  }
-  #layering-button-grid {
-    top: 0;
-    position: sticky;
-  }
-  #layering-hide-header {
-    grid-area: layer-hide-header;
-  }
-  #layering-wce-hide-div {
-    box-sizing: border-box;
-    grid-area: layer-hide-grid;
-    width: 100%;
-    height: calc(100% - min(2vh, 1vw));
-    padding-left: min(2vh, 1vw);
-    padding-right: min(2vh, 1vw);
-    align-self: self-start;
-  }
-
   .wce-chat-room-select,
   #wce-chat-garble-label {
     font-size: 80%;
@@ -374,6 +346,37 @@ export default function wceStyles(): void {
     --button-color: #666;
   }
   `;
+  if (GameVersion === "R129") {
+    css += `
+    #layering {
+      grid-template:
+        "asset-header button-grid" min-content
+        "asset-grid asset-grid" min-content
+        "layer-header layer-header" min-content
+        "layer-grid layer-grid" auto
+        "layer-hide-header layer-hide-header" min-content
+        "layer-hide-grid layer-hide-grid" auto
+        / auto min-content
+      ;
+    }
+    #layering-button-grid {
+      top: 0;
+      position: sticky;
+    }
+    #layering-hide-header {
+      grid-area: layer-hide-header;
+    }
+    #layering-wce-hide-div {
+      box-sizing: border-box;
+      grid-area: layer-hide-grid;
+      width: 100%;
+      height: calc(100% - min(2vh, 1vw));
+      padding-left: min(2vh, 1vw);
+      padding-right: min(2vh, 1vw);
+      align-self: self-start;
+    }
+    `;
+  }
   const head = document.head || document.getElementsByTagName("head")[0];
   const style = document.createElement("style");
   style.appendChild(document.createTextNode(css));


### PR DESCRIPTION
Xref [BondageProjects/Bondage-College#6415](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/6415)

R130 will switch the layering screen to BC's more standardized DOM screen template API, which has a few consequences for WCE's item-hiding extension due to changes in the DOM tree layout. Most prominently, the menubar and heading positions have been changed, they now more closely resembling WCE's own CSS layout rearrangement patch. Secondly, there's been a general increase in the use of [`<fieldset>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/fieldset) elements for logical grouping and some minor styling.

Examples
----------
Before (left) and after (right) R130:

<img width="2624" height="1291" alt="image" src="https://github.com/user-attachments/assets/7a3b626a-0ce0-4631-af34-f571b7bcfae7" />

Example video:

https://github.com/user-attachments/assets/a83ec7b9-3f9e-40ac-b074-1f974268bf05